### PR TITLE
Return CORS header for / in case of NotFound

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,9 @@ async fn handle_index(request: Request<State>) -> tide::Result<Response> {
         let resources = site.resources.read().unwrap();
         match resources.get("/index") {
             Some(..) => Ok(render_and_build_response(&site, "/index".to_owned())),
-            None => Ok(Response::new(StatusCode::NotFound)),
+            None => Ok(Response::builder(StatusCode::NotFound)
+                      .header("Access-Control-Allow-Origin", "*")
+                      .build())
         }
     } else {
         return Ok(Response::new(StatusCode::NotFound));


### PR DESCRIPTION
Return CORS header for / in case of NotFound, when there is an otherwise valid server; nostrudel needs this to be able to add the media server in the first place, as it will 'detect' the server by accessing the root.